### PR TITLE
Add support for building as a Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y make
+
+ADD . /build
+
+RUN make -C /build/01_kallistios
+RUN make -C /build/02_mkdcdisc
+RUN make -C /build/03_doom64 clone
+
+ENTRYPOINT ["/build/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+cp /mnt/*.wad /mnt/*.z64 /build/00_game_files
+
+make -C /build/00_game_files
+
+git -C /tmp/doom64-dc pull
+
+make -C /build/03_doom64 link build print
+
+chown --reference /mnt /build/doom64.cdi
+cp --preserve /build/doom64.cdi /mnt


### PR DESCRIPTION
This adds a Dockerfile and entrypoint script for fully dockerizing the Doom 64 build process, which reduces everything to just these commands:

    docker build -t doom64-dc .
    docker run -v <path-to-directory>:/mnt/ doom64-dc

with `doom64.z64` and `doom64.wad` placed in the mounted directory, and `doom64.cdi` outputted to that same directory.

The image could also be pushed to Docker Hub to significantly speed up the build process for others, as it takes about an hour or so for all the dependencies to build on my machine (the game itself only takes a few seconds).

I implemented this around the existing Makefile structure, it runs `01_kallistios`, `02_mkdcdisc` and the clone step of `03_doom64` as part of the container build process, then runs `00_game_files` and the remaining steps of `03_doom64` at container runtime.